### PR TITLE
Implemented Z_NOBLOCK flag

### DIFF
--- a/lib/filecopy.c
+++ b/lib/filecopy.c
@@ -91,10 +91,15 @@ bool safe_filecopy(int src, int dst) {
   return true;
 }
 
-bool atomic_filecopy(int src, int dst) {
+bool atomic_filecopy(int src, int dst, bool no_block) {
   bool success = false;
 
-  if (flock(src, LOCK_SH) != 0) {
+  int lock = LOCK_SH;
+  if (no_block) {
+    lock |= LOCK_NB;
+  }
+
+  if (flock(src, lock) != 0) {
     LOG_DEBUG("Failed to get shared lock for source file (fd = %d): %s", src,
               strerror(errno));
     return false;

--- a/lib/filecopy.h
+++ b/lib/filecopy.h
@@ -7,6 +7,6 @@ bool filecopy(int src, int dst);
 
 bool safe_filecopy(int src, int dst);
 
-bool atomic_filecopy(int src, int dst);
+bool atomic_filecopy(int src, int dst, bool no_block);
 
 #endif /* __ZEUGL_FILECOPY_H__ */

--- a/lib/filecopy.h
+++ b/lib/filecopy.h
@@ -5,7 +5,7 @@
 
 bool filecopy(int src, int dst);
 
-bool safe_filecopy(int src, int dst);
+bool safe_filecopy(int src, int dst, bool no_block);
 
 bool atomic_filecopy(int src, int dst, bool no_block);
 

--- a/lib/filecopy.h
+++ b/lib/filecopy.h
@@ -5,6 +5,8 @@
 
 bool filecopy(int src, int dst);
 
+bool safe_filecopy(int src, int dst);
+
 bool atomic_filecopy(int src, int dst);
 
 #endif /* __ZEUGL_FILECOPY_H__ */

--- a/lib/zeugl.c
+++ b/lib/zeugl.c
@@ -129,9 +129,9 @@ int zopen(const char *fname, int flags, ...) {
       LOG_DEBUG("Using mode %04jo from original file '%s' (fd = %d)",
                 (uintmax_t)file->mode, file->orig, fd);
 
-      if (!atomic_filecopy(fd, file->fd, false)) {
-        LOG_DEBUG("Failed to copy content from original file '%s' (fd = %d) to "
-                  "temporary file '%s' (fd = %d): %s",
+      if (!atomic_filecopy(fd, file->fd, (flags | Z_NOBLOCK))) {
+        LOG_DEBUG("Failed to copy content from original file '%s' (fd = %d) "
+                  "to temporary file '%s' (fd = %d): %s",
                   file->orig, fd, file->temp, file->fd, strerror(errno));
         if (close(fd) == 0) {
           LOG_DEBUG("Closed original file '%s' (fd = %d)", file->orig, fd);

--- a/lib/zeugl.c
+++ b/lib/zeugl.c
@@ -129,7 +129,7 @@ int zopen(const char *fname, int flags, ...) {
       LOG_DEBUG("Using mode %04jo from original file '%s' (fd = %d)",
                 (uintmax_t)file->mode, file->orig, fd);
 
-      if (!atomic_filecopy(fd, file->fd)) {
+      if (!atomic_filecopy(fd, file->fd, false)) {
         LOG_DEBUG("Failed to copy content from original file '%s' (fd = %d) to "
                   "temporary file '%s' (fd = %d): %s",
                   file->orig, fd, file->temp, file->fd, strerror(errno));

--- a/lib/zeugl.h
+++ b/lib/zeugl.h
@@ -24,6 +24,8 @@
  *
  *                  Z_CREATE
  *                      if filename does not exist, create it as a regular file.
+ *                      Note that this flag requires you  to  specify  the  mode
+ *                      argument.
  *
  *                  Z_APPEND
  *                      the file offset is positioned at the  end  of  the  file

--- a/lib/zeugl.h
+++ b/lib/zeugl.h
@@ -6,6 +6,7 @@
 #define Z_CREATE 1 << 0
 #define Z_APPEND 1 << 1
 #define Z_TRUNCATE 1 << 2
+#define Z_NOBLOCK 1 << 2
 
 /**
  * @brief           Begins an  atomic  file  transaction  by  returning  a  file
@@ -31,6 +32,9 @@
  *                  Z_TRUNCATE
  *                      the content of the original is  never  copied  into  the
  *                      temporary copy.
+ *
+ *                  Z_NOBLOCK
+ *                      the file does not block on advisory locking.
  *
  * @param mode      The mode argument specifies the file mode bits to be applied
  *                  when a new file is created. If Z_CREATE is not specified  in

--- a/lib/zeugl.h
+++ b/lib/zeugl.h
@@ -27,7 +27,9 @@
  *
  *                  Z_APPEND
  *                      the file offset is positioned at the  end  of  the  file
- *                      instead of at the start of the file.
+ *                      instead of at the start of the file. However,  the  file
+ *                      offset is not repositioned to the end of the file before
+ *                      each write like O_APPEND in open(2).
  *
  *                  Z_TRUNCATE
  *                      the content of the original is  never  copied  into  the

--- a/lib/zeugl.h
+++ b/lib/zeugl.h
@@ -43,7 +43,9 @@
  *                      the original file to the temporary copy  if  it  detects
  *                      that another process is writing  to  the  original  file
  *                      simultaneously. In all of these cases, the function will
- *                      return error and errno will be set to EBUSY.
+ *                      return error and errno will be set to EBUSY. Please note
+ *                      that this flag does not guarantee that the function call
+ *                      does not block for any other reasons.
  *
  * @param mode      The mode argument specifies the file mode bits to be applied
  *                  when a new file is created. If Z_CREATE is not specified  in

--- a/lib/zeugl.h
+++ b/lib/zeugl.h
@@ -34,7 +34,12 @@
  *                      temporary copy.
  *
  *                  Z_NOBLOCK
- *                      the file does not block on advisory locking.
+ *                      the file  does  not  block  on  advisory  locking  (file
+ *                      locks). Futhermore, the function will not retry  copying
+ *                      the original file to the temporary copy  if  it  detects
+ *                      that another process is writing  to  the  original  file
+ *                      simultaneously. In all of these cases, the function will
+ *                      return error and errno will be set to EBUSY.
  *
  * @param mode      The mode argument specifies the file mode bits to be applied
  *                  when a new file is created. If Z_CREATE is not specified  in
@@ -50,7 +55,11 @@
  * @note            There are some measures to try to detect if another  process
  *                  is writing to the original file while  zopen()  creates  the
  *                  temporary copy. However, this cannot  be  guaranteed  unless
- *                  the process respects file locks.
+ *                  the other processes modifying to the original file  respects
+ *                  advisory locks (file locks). Upon detecting other  processes
+ *                  writing to the original file while copying it, zopen()  will
+ *                  continuously retry copying unless the Z_NOBLOCK bit  is  set
+ *                  in the flag argument.
  */
 int zopen(const char *filename, int flags, ... /* mode_t mode */);
 


### PR DESCRIPTION
- **Refactored automic file copy into two functions**
- **Added no-block functionallity to atomic file copy**
- **Implemented Z_NOBLOCK to not block on advisory locks**
- **Copying of original file is now retried unless Z_NOBLOCK**
- **Added note on how Z_APPEND is different from O_APPEND**
- **Add note on how Z_CREATE required the mode argument to be specified**
- **Add note on Z_NOBLOCK not guaranteing no block**
